### PR TITLE
Fix for item_sum being < 0

### DIFF
--- a/app/controllers/spree/paypal_controller.rb
+++ b/app/controllers/spree/paypal_controller.rb
@@ -155,7 +155,7 @@ module Spree
 
     def payment_details items
       item_sum = items.sum { |i| i[:Quantity] * i[:Amount][:value] }
-      if item_sum.zero?
+      if item_sum <= 0
         # Paypal does not support no items or a zero dollar ItemTotal
         # This results in the order summary being simply "Current purchase"
         {


### PR DESCRIPTION
It is possible for item sum to be negative where the order total is
above zero. This is because shipping is not included in the item total
but there may be adjustments made on the order to cover that amount
